### PR TITLE
UPDATE ZenTest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     Ascii85 (1.0.2)
-    ZenTest (4.7.0)
+    ZenTest (4.9.5)
     action-guard (1.2.1)
     actionmailer (3.2.3)
       actionpack (= 3.2.3)


### PR DESCRIPTION
This repos uses a lot of old dependencies. This can't be good : there
have been 14 new rails versions since the one used here.

While this will need to be migrated to rails-4 in a not so far future,
there is something that can't wait : updating ZenTest.

Trying to install dependencies right now using ruby-2.0 with `bundle
install` trigger this error :

```
Installing ZenTest (4.7.0)
Gem::InstallError: ZenTest requires RubyGems version ~> 1.8. Try 'gem update --system' to update RubyGems itself.
```

That's because ruby-2.0 uses rubygems-2.0, and ZenTest enforce using 1.8
branch. Updating ZenTest solves this without breaking specs.

I'm not even sure why ZenTest has been added to bundle, actually. We
used that back in time for autotest, but it has now been superseed by
guard, which is also included in bundle.

As ZenTest has some other features than autotest, I won't remove it
right now and wait to be more aclimated to codebase.
