### PR TITLE
REFACTOR switch to postgres

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "haml-rails"
 
 gem "action-guard", "~> 1.2.0"
 #gem 'guid'
-gem 'sqlite3'
+gem 'pg'
 gem "recaptcha", :require => "recaptcha/rails"
 gem 'prawn'
 gem 'htmlentities'
@@ -20,6 +20,7 @@ group :test do
   gem 'shoulda-matchers'
   gem "capybara"
   gem 'guard-rspec'
+  gem 'database_cleaner'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.3.1)
+    database_cleaner (1.2.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
     execjs (1.3.1)
@@ -109,6 +110,7 @@ GEM
       Ascii85 (~> 1.0.0)
       hashery (~> 2.0)
       ruby-rc4
+    pg (0.17.0)
     polyglot (0.3.3)
     prawn (0.12.0)
       pdf-reader (>= 0.9.0)
@@ -188,8 +190,6 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.6)
-    sqlite3 (1.3.6-x86-mingw32)
     therubyracer (0.10.2)
       libv8 (~> 3.3.10)
     thor (0.14.6)
@@ -221,19 +221,20 @@ DEPENDENCIES
   bcrypt-ruby
   capybara
   coffee-rails (~> 3.2.1)
+  database_cleaner
   execjs
   factory_girl_rails
   guard-rspec
   haml-rails
   htmlentities
   jquery-rails
+  pg
   prawn
   rails (= 3.2.3)
   recaptcha
   rspec-rails (~> 2.9)
   sass-rails (~> 3.2.3)
   shoulda-matchers
-  sqlite3
   therubyracer
   uglifier (>= 1.0.3)
   vlad

--- a/README.md
+++ b/README.md
@@ -2,3 +2,41 @@ propile
 =======
 
 Community Conference Program Compiler
+
+
+## Installation
+
+Some environment variables are needed to set up the app :
+
+* `PROPILE_DEV_DB_NAME`
+* `PROPILE_DEV_DB_USER`
+* `PROPILE_DEV_DB_PASS`
+* `PROPILE_TEST_DB_NAME`
+* `PROPILE_TEST_DB_USER`
+* `PROPILE_TEST_DB_PASS`
+* `PROPILE_PROD_DB_NAME`
+* `PROPILE_PROD_DB_USER`
+* `PROPILE_PROD_DB_PASS`
+
+You only need the first six for a development environment, set them in your
+.bashrc, .tmuxrc, or whatever you want than will set environment variables for
+your application.
+
+To create databases :
+
+    $ sudo -u postgres psql
+
+    postgres=# create database <PROPILE_DEV_DB_NAME>;
+    postgres=# create user <PROPILE_DEV_DB_USER> with password '<PROPILE_DEV_DB_PASS>';
+    postgres=# grant all privileges on database <PROPILE_DEV_DB_NAME> to <PROPILE_DEV_DB_USER>;
+    postgres=# create database <PROPILE_TEST_DB_NAME>;
+    postgres=# create user <PROPILE_TEST_DB_USER> with password '<PROPILE_TEST_DB_PASS>';
+    postgres=# grant all privileges on database <PROPILE_TEST_DB_NAME> to <PROPILE_TEST_DB_USER>;
+    postgres=# ^d
+
+    $ bundle exec rake db:migrate
+    $ RAILS_ENV=test bundle exec rake db:migrate
+
+Then, ensure tests are passing :
+
+    bundle exec rspec spec/

--- a/app/controllers/presenters_controller.rb
+++ b/app/controllers/presenters_controller.rb
@@ -10,7 +10,15 @@ class PresentersController < ApplicationController
       @presenters = Presenter.all.sort_by { |p| p.email.upcase }  
       @presenters = sort_direction=="asc" ? @presenters :  @presenters.reverse 
     else
-      @presenters = Presenter.order( "upper("+sort_column+") " + sort_direction)
+      sort = begin
+        if ( Presenter.attribute_names - %w[created_at] ).include?( sort_column.to_s )
+          "upper(cast (#{sort_column} as text))"
+        else
+          'created_at'
+        end
+      end
+
+      @presenters = Presenter.order( "#{sort} #{sort_direction}" )
     end
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,23 +1,23 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
 development:
-  adapter: sqlite3
-  database: data/development.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: <%= ENV[ 'PROPILE_DEV_DB_NAME' ] %>
   pool: 5
-  timeout: 5000
+  username: <%= ENV[ 'PROPILE_DEV_DB_USER' ] %>
+  password: <%= ENV[ 'PROPILE_DEV_DB_PASS' ] %>
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this data to the same as development or production.
 test:
-  adapter: sqlite3
-  database: ":memory:"
+  adapter: postgresql
+  encoding: unicode
+  database: <%= ENV[ 'PROPILE_TEST_DB_NAME' ] %>
+  pool: 5
+  username: <%= ENV[ 'PROPILE_TEST_DB_USER' ] %>
+  password: <%= ENV[ 'PROPILE_TEST_DB_PASS' ] %>
 
 production:
-  adapter: sqlite3
-  database: data/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: <%= ENV[ 'PROPILE_PROD_DB_NAME' ] %>
   pool: 5
-  timeout: 5000
+  username: <%= ENV[ 'PROPILE_PROD_DB_USER' ] %>
+  password: <%= ENV[ 'PROPILE_PROD_DB_PASS' ] %>

--- a/spec/controllers/program_entries_controller_spec.rb
+++ b/spec/controllers/program_entries_controller_spec.rb
@@ -111,7 +111,7 @@ describe ProgramEntriesController do
   
         it "redirects to the program_entry" do
           put :update, {:id => program_entry.to_param, :program_entry => valid_attributes}
-          response.should redirect_to( :controller => 'programs', :action => 'edit' )
+          response.should redirect_to( :controller => 'programs', :action => 'edit', id: program_entry.program.id )
         end
       end
   

--- a/spec/controllers/programs_controller_spec.rb
+++ b/spec/controllers/programs_controller_spec.rb
@@ -39,37 +39,37 @@ describe ProgramsController do
       entry.comment = "helaba!"
       program.program_entries << entry
 
-      me = Presenter.new
-      me.email = "presenter@company.com"
-      me.name = "Jane Presenter"
-      me.bio = "I've led an interesting life"
-      me.should be_valid
-      me.save
+      @me = Presenter.new
+      @me.email = "presenter@company.com"
+      @me.name = "Jane Presenter"
+      @me.bio = "I've led an interesting life"
+      @me.should be_valid
+      @me.save
 
-      friend = Presenter.new
-      friend.email = "irene@company.com"
-      friend.name = "Irène Presenter"
-      friend.bio = "I've led an interesting life. A bientôt! Irène"
-      friend.should be_valid
-      friend.save
+      @friend = Presenter.new
+      @friend.email = "irene@company.com"
+      @friend.name = "Irène Presenter"
+      @friend.bio = "I've led an interesting life. A bientôt! Irène"
+      @friend.should be_valid
+      @friend.save
 
-      session = Session.new
-      session.title = "Session expérimentale"
-      session.description = "We're going to do things nobody's ever done before. At least Irène hasn't done them."
-      session.topic = "team"
-      session.laptops_required = 'no'
-      session.duration = "75 min"
-      session.first_presenter = me
-      session.second_presenter = friend
-      session.state = Session::CONFIRMED
-      session.should be_valid
-      session.save
+      @session = Session.new
+      @session.title = "Session expérimentale"
+      @session.description = "We're going to do things nobody's ever done before. At least Irène hasn't done them."
+      @session.topic = "team"
+      @session.laptops_required = 'no'
+      @session.duration = "75 min"
+      @session.first_presenter = @me
+      @session.second_presenter = @friend
+      @session.state = Session::CONFIRMED
+      @session.should be_valid
+      @session.save
 
       entry = ProgramEntry.new
       entry.slot = 1
       entry.track = 2
       entry.comment = "hocus pocus!"
-      entry.session = session
+      entry.session = @session
       program.program_entries << entry
       program.should be_valid
       program.save
@@ -132,6 +132,7 @@ describe ProgramsController do
         
         get :export, :id => program.to_param
         assigns(:program).should eq(program)
+
         response.should be_succes
 #        puts "-------------"
 #        puts response.body
@@ -139,9 +140,9 @@ describe ProgramsController do
         response.body.should  match(/Legend/)
         response.body.should  match(/Session descriptions/)
         response.body.should  match(/Presenters/)
-        response.body.should match("<a href=\"#presenter_1\">Jane Presenter</a>")
-        response.body.should match("<a href=\"#presenter_2\">Ir&egrave;ne Presenter</a>")
-        response.body.should match("<a href=\"#session_1\">Session exp&eacute;rimentale</a>")
+        response.body.should match("<a href=\"#presenter_#{@me.id}\">Jane Presenter</a>")
+        response.body.should match("<a href=\"#presenter_#{@friend.id}\">Ir&egrave;ne Presenter</a>")
+        response.body.should match("<a href=\"#session_#{@session.id}\">Session exp&eacute;rimentale</a>")
         response.body.should_not match("Irène")
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,9 +23,17 @@ RSpec.configure do |config|
   config.filter_run_excluding :broken => true
   config.filter_run 
   config.run_all_when_everything_filtered = true
-end
 
- load_schema = lambda {  
-   load "#{Rails.root.to_s}/db/schema.rb" # use db agnostic schema by default  
- }
- silence_stream(STDOUT, &load_schema)
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :deletion
+    DatabaseCleaner.clean_with( :truncation )
+  end
+
+  config.before :each do
+    DatabaseCleaner.start
+  end
+
+  config.after :each do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
Database has been changed to use postgres rather than sqlite.

Database credentials has to be provided as environment variables :
- `PROPILE_DEV_DB_NAME`
- `PROPILE_DEV_DB_USER`
- `PROPILE_DEV_DB_PASS`
- `PROPILE_TEST_DB_NAME`
- `PROPILE_TEST_DB_USER`
- `PROPILE_TEST_DB_PASS`
- `PROPILE_PROD_DB_NAME`
- `PROPILE_PROD_DB_USER`
- `PROPILE_PROD_DB_PASS`

Only the first six are needed for a typical development box.

Using environment variables is a good thing because :
- each developer may use configuration she wants on her box
- credentials are not committed in repos (especially important here
  since it's a public repos)

Instructions has been added in readme to explain installation.

Migration was quite straightforward, with those few problems :
- database reset was ensured by loading schemas, which doesn't work with
  postgres
- id were hardcoded in specs, counting of schemas load to reset id
  counter
- an UPPER function was used against a datetime field (created_at),
  which does not work in postgres without a type cast.

Please not that database configuration here are for local use, because
(unless it has changed since last year) heroku override
config/database.yml with its own configuration (but this should have no
negative impact).

Close #1

Details :
- ADD pg gem
- CHANGE database configuration
- ADD installation instructions in readme
- FIX UPPER typecast for postgres (and fix sql injection btw)
- REFACTOR remove attempt to recreate db from spec_helper (thefuck?)
- ADD database_cleaner
- FIX hardcoded id in in programs controller spec
- FIX implicit id in program entries controller spec
