### PR TITLE
ADD mailcatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ a presenter profile should still be created as `me.presenter` to avoid app
 crashing when reaching dashboard.
 
 
+### Mails
+
+To be able to inspect mails on development env, please install `mailcatcher` :
+
+    gem install mailcatcher
+
+
+It will proxies all mails to a web interface that you can start using :
+
+    mailcatcher
+
+
+No mail will be sent out. You can run the application without installing or
+running mailcatcher, you just won't be able to inspect mails.
+
+
 ## Findings about design
 
 ### Sessions and sessions

--- a/app/controllers/propile_configs_controller.rb
+++ b/app/controllers/propile_configs_controller.rb
@@ -104,15 +104,6 @@ class PropileConfigsController < ApplicationController
     end
   end
 
-  def toggle_send_mails
-    PropileConfig.toggle_send_mails
-
-    respond_to do |format|
-      format.html { redirect_to propile_configs_url }
-      format.json { head :no_content }
-    end
-  end
-
   def start_conference
     Program.destroy_all
     ProgramEntry.destroy_all

--- a/app/models/propile_config.rb
+++ b/app/models/propile_config.rb
@@ -23,20 +23,6 @@ class PropileConfig < ActiveRecord::Base
     set( prop_name, (!is_set(prop_name)).to_s )
   end
 
-  def self.send_mails_active?
-    Propile::Application.config.action_mailer.delivery_method == :sendmail 
-  end
-
-  def self.toggle_send_mails
-    if Propile::Application.config.action_mailer.delivery_method == :sendmail
-      new_deliver_method = :test
-    else
-      new_deliver_method = :sendmail
-    end
-    Propile::Application.config.action_mailer.delivery_method = new_deliver_method
-    ActionMailer::Base.delivery_method = new_deliver_method
-  end
-
   def self.submit_session_active?
     is_set( SUBMIT_SESSION_ACTIVE )
   end

--- a/app/views/propile_configs/index.html.erb
+++ b/app/views/propile_configs/index.html.erb
@@ -34,15 +34,6 @@
 <div> <i> Not persisted! (lost when server restarted)</i></div>
 <table>
   <tr>
-    <%= form_for(PropileConfig.new, :url => url_for(:action => 'toggle_send_mails'), method: :put ) do |f| %>
-    <td> Mails are sent (test-env): </td> 
-    <td> <%= PropileConfig.send_mails_active? %> </td> 
-    <td> <%= f.submit "toggle" %> </td>
-    <td> <i> Are mails sent when submitting a session, reviewing a session, making comments on reviews, or resetting password?</i>
-    </td>
-  </tr> 
-    <% end %>
-  <tr>
     <%= form_for(PropileConfig.new, :url => url_for(:action => 'change_last_login'), method: :put ) do |f| %>
       <td> Last login (current account): </td> 
       <!--td> <%= f.text_field  "new_last_login", :value => current_account.last_login %> </td--> 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,8 +16,13 @@ Propile::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { :host => 'dev:3000' }
-  #config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.delivery_method = :test
+
+  # To use mailcatcher :
+  #
+  # 1. install it : `gem install mailcatcher`
+  # 2. run it : `mailcatcher`
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
 
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,6 @@ Propile::Application.routes.draw do
     get 'statistics', :on => :collection
     put 'toggle', :on => :collection
     put 'change_last_login', :on => :collection
-    put 'toggle_send_mails', :on => :collection
     get 'start_conference', :on => :collection
   end
 


### PR DESCRIPTION
[Mailcatcher](https://github.com/sj26/mailcatcher) is a smtp proxy that catch any outbound mail and presents
it in a web interface, ensuring no email goes outside our dev box.

This will make it easier to debug mail related features, which are
currently about sending mails to real people or not sending mails at
all.

Project owner recommands not to include it in Gemfile, so it has to be
installed locally by developpers :

```
gem install mailcatcher
```

Then, to be able to see mails running :

```
mailcatcher
```

this will create a server on port 1080 (specified in command output).

It is ok not to install mailcatcher or running it as it won't hurt
application runtime - you just won't be able to see mails.

Accordingly, code that enables / disables mail sending has been removed,
since getting mails content is just about running mailcatcher.

Close #12

Details :
- ADD mailcatcher configuration
- ADD doc about mailcatcher in readme
- REMOVE dev mail sending toggler
