### PR TITLE
Fix account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,7 @@ The `Session` model is related to former one.
 
 ### Creating accounts
 
-Even if there's an `AccountsController`, it seems it's expected to create
-accounts manually from rails console :
+To create account, go to the [configuration page](http://0.0.0.0:3000/profile_configs) and
+use the "New presenter/Maintainer" link in the "Maintainers" section.
 
-* `accounts/new` is accessible only for logged in users
-* this form displays no input anyway, except the submit one
-
-There's also an ajax form in configuration page, but I just could not getting
-it to work properly.
-
-So, as for now, let just create users the same way you did to create your own,
-just not setting them as maintainer.
+Upon completion, a confirmation email will be sent.

--- a/app/assets/javascripts/propile_configs.js.coffee
+++ b/app/assets/javascripts/propile_configs.js.coffee
@@ -1,3 +1,6 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
+
+$ ->
+  $( '#new_presenter_link' ).click -> $( '#confirmation-sent' ).hide()

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -493,3 +493,4 @@ input.adddelete_button:hover {
     background: lavender;
 }
 
+#confirmation-sent { display: none; }

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,4 +1,5 @@
 class AccountsController < ApplicationController
+  skip_before_filter :authorize_action, only: :confirm
   def index
     @accounts = Account.all
   end
@@ -32,6 +33,22 @@ class AccountsController < ApplicationController
       redirect_to @account, notice: 'Account was successfully updated.'
     else
       render action: "edit"
+    end
+  end
+
+  def confirm
+    @account = Account.where( confirmation_token: params[ :id ] ).first
+
+    if @account
+      if @account.confirmed?
+        redirect_to root_path
+      else
+        @account.update_attribute( :confirmed_at, Time.now )
+        sign_in @account
+        redirect_to edit_account_password_path
+      end
+    else
+      redirect_to root_path, alert: "We could not find your account. Please contact administrators."
     end
   end
 

--- a/app/controllers/presenters_controller.rb
+++ b/app/controllers/presenters_controller.rb
@@ -61,6 +61,8 @@ class PresentersController < ApplicationController
 
     respond_to do |format|
       if @presenter.save
+        AccountMailer.confirmation( @presenter.account ).deliver
+
         format.html {redirect_to :back, notice: 'Presenter was successfully created.'}
         format.json {render json: @product }
         format.js

--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -1,0 +1,8 @@
+class AccountMailer < ActionMailer::Base
+  default from: "contact@conference-agile.fr"
+
+  def confirmation( account )
+    @account = account
+    mail to: account.email
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,11 +7,12 @@ class Account < ActiveRecord::Base
   include Authenticable 
   on_account_reset :send_reset_message
 
+  before_create :generate_confirmation_token
   before_create :generate_authentication_token
 
   attr_accessible :email, :password, :password_confirmation, :role, :last_login
 
-  has_one :presenter
+  has_one :presenter, dependent: :destroy, inverse_of: :account
 
   attr_accessor :password
   validates_confirmation_of :password

--- a/app/models/presenter.rb
+++ b/app/models/presenter.rb
@@ -5,7 +5,7 @@ class Presenter < ActiveRecord::Base
   has_many :reviews
   has_many :comments
   has_many :votes
-  belongs_to :account
+  belongs_to :account, inverse_of: :presenter
 
   attr_accessible :bio, :email, :name, :role
   attr_accessible :twitter_id, :profile_image, :website

--- a/app/views/account_mailer/confirmation.text.erb
+++ b/app/views/account_mailer/confirmation.text.erb
@@ -1,0 +1,6 @@
+Hello <%= @account.email %>,
+
+A <%= @account.role %> account has been created for you.
+
+You can confirm it using this link :
+<%= confirm_account_url( @account.confirmation_token ) %>

--- a/app/views/presenters/_small_form.html.erb
+++ b/app/views/presenters/_small_form.html.erb
@@ -3,7 +3,6 @@
   <% if current_account.maintainer? %>
     <div class="outlined">
       <div>
-        <%= f.label :name %> <%= text_field :presenter, :name, :size => "70" %> 
         <%= f.label :email %> <%= text_field :presenter, :email, :disabled => (!current_account.maintainer?), :size => "70" %> 
         <%= f.select :role, [Account::Maintainer, Account::Presenter]  %>
       </div>

--- a/app/views/presenters/create.js.erb
+++ b/app/views/presenters/create.js.erb
@@ -1,2 +1,3 @@
 $('#new_presenter_link').show()
+$('#confirmation-sent').fadeIn()
 $('#new_presenter').remove();

--- a/app/views/propile_configs/index.html.erb
+++ b/app/views/propile_configs/index.html.erb
@@ -39,28 +39,31 @@
       <!--td> <%= f.text_field  "new_last_login", :value => current_account.last_login %> </td--> 
       <td> <%= f.text_field  "new_last_login", :value => session[:previous_login] %> </td> 
       <td> <%= f.submit "update" %> </td>
-      <td> <i> time of previous login (in session) --> to test the dashboard-functionalities. 
+      <td> <i> time of previous login (in session) --> to test the dashboard-functionalities. </i>
       </td>
     <% end %>
   </tr> 
 </table>
 
-<h1>Maintainers</h1>
-<%= link_to 'New presenter/Maintainer', new_presenter_path, :remote => true, :id => "new_presenter_link" %>   
-<table>
-<% @presenters.each_with_index do |presenter, i| %>
-  <% if presenter.account.maintainer? %>
-    <tr >
-      <td> <%= i+1 %> </td>
-      <td> <%= link_to presenter.name, presenter %></td>
-      <td><%= presenter.email%> </td>
-      <td class="nowrap" ><%= l presenter.created_at %> </td>
-      <td class="nowrap" ><%= l presenter.updated_at %> </td>
-      <td><%= guarded_link_to 'Edit', controller: 'presenters', action: 'edit', id: presenter.to_param %></td> 
-    </tr>
+<div id="account-creation">
+  <h1>Maintainers</h1>
+  <%= link_to 'New presenter/Maintainer', new_presenter_path, :remote => true, :id => "new_presenter_link" %>   
+  <p id="confirmation-sent">Confirmation email has been sent</p>
+  <table>
+  <% @presenters.each_with_index do |presenter, i| %>
+    <% if presenter.account.maintainer? %>
+      <tr >
+        <td> <%= i+1 %> </td>
+        <td> <%= link_to presenter.name, presenter %></td>
+        <td><%= presenter.email%> </td>
+        <td class="nowrap" ><%= l presenter.created_at %> </td>
+        <td class="nowrap" ><%= l presenter.updated_at %> </td>
+        <td><%= guarded_link_to 'Edit', controller: 'presenters', action: 'edit', id: presenter.to_param %></td> 
+      </tr>
+    <% end %>
   <% end %>
-<% end %>
-</table>
+  </table>
+</div>
 
 
 <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,9 @@ Propile::Application.routes.draw do
 
   resources :pages, :only => :show
   
-  resources :accounts, except: [:destroy]
+  resources :accounts, except: [:destroy] do
+    get 'confirm', on: :member
+  end
 
   resources :comments, except: [:destroy] 
 

--- a/db/migrate/20131111152514_add_confirmation_token_to_accounts.rb
+++ b/db/migrate/20131111152514_add_confirmation_token_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddConfirmationTokenToAccounts < ActiveRecord::Migration
+  def change
+    add_column :accounts, :confirmation_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130909190234) do
+ActiveRecord::Schema.define(:version => 20131111152514) do
 
   create_table "accounts", :force => true do |t|
     t.string   "email",                :limit => 150,                          :null => false
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(:version => 20130909190234) do
     t.datetime "created_at",                                                   :null => false
     t.datetime "updated_at",                                                   :null => false
     t.datetime "last_login"
+    t.string   "confirmation_token"
   end
 
   add_index "accounts", ["authentication_token"], :name => "index_accounts_on_authentication_token"

--- a/lib/authenticable.rb
+++ b/lib/authenticable.rb
@@ -76,6 +76,13 @@ module Authenticable
     end
   end
 
+  def generate_confirmation_token
+    while (true) 
+      self.confirmation_token = TokenGenerator.generate_token
+      return confirmation_token if unique_token?(confirmation_token)
+    end
+  end
+
   private 
   def unique_token? token
     return ! self.class.find_by_authentication_token(token)

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -30,12 +30,12 @@ describe AccountsController do
       end
     end
 
-  describe "GET new" do
-    it "assigns a new account as @account" do
-      get :new, {}
-      assigns(:account).should be_a_new(Account)
+    describe "GET new" do
+      it "assigns a new account as @account" do
+        get :new, {}
+        assigns(:account).should be_a_new(Account)
+      end
     end
-  end
 
     describe "GET edit" do
       it "assigns the requested account as @account" do
@@ -136,4 +136,52 @@ describe AccountsController do
     end
   end
 
+  describe 'confirm' do
+    describe 'for unconfirmed account' do
+      before :each do
+        @account = build_stubbed :account
+        @account.stub :update_attribute
+        @account.stub :save # called from #sign_in
+      end
+
+      describe 'providing correct confirmation token' do
+        before :each do
+          Account.stub( :where ).and_return( [ @account ] )
+        end
+
+        it 'confirms account' do
+          @account.should_receive( :update_attribute ).with( :confirmed_at, an_instance_of( Time ) )
+          get :confirm, id: 'token'
+        end
+
+        it 'redirects to password edition page' do
+          get :confirm, id: 'token'
+          response.should redirect_to edit_account_password_path
+        end
+      end
+
+      describe 'providing unknown confirmation token' do
+        before :each do
+          Account.stub( :where ).and_return( [] )
+          get :confirm, id: 'token'
+        end
+
+        it 'redirects to home page' do
+          response.should redirect_to root_path
+        end
+      end
+    end
+
+    describe 'for confirmed account' do
+      before :each do
+        @account = build_stubbed :confirmed_account
+        Account.stub( :where ).and_return( [ @account ] )
+        get :confirm, id: 'token'
+      end
+
+      it 'silently redirects to home page' do
+        response.should redirect_to root_path
+      end
+    end
+  end
 end

--- a/spec/controllers/presenters_controller_spec.rb
+++ b/spec/controllers/presenters_controller_spec.rb
@@ -103,6 +103,13 @@ describe PresentersController do
           assigns(:presenter).should be_persisted
         end
 
+        it 'sends confirmation email' do
+          request.env["HTTP_REFERER"] = 'dummy'
+          post :create, {:presenter => valid_attributes}
+
+          ActionMailer::Base.deliveries.should_not be_empty
+        end
+
         it "redirects to the created presenter" do
           request.env["HTTP_REFERER"] = 'dummy'
           post :create, {:presenter => valid_attributes}

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,8 +52,8 @@ FactoryGirl.define do
     factory :confirmed_account do
       password 'secret'
       password_confirmation 'secret'
+      confirmed_at { Time.now }
       after( :create ) do |account|
-        account.confirm!
         account.create_presenter!
       end
     end
@@ -62,6 +62,10 @@ FactoryGirl.define do
   factory :presenter_account, :class => Account do
     sequence( :email ) { |n| "presenter_#{n}@example.com" }
     role Account::Presenter
+
+    after( :create ) do |account|
+      account.create_presenter! unless account.presenter
+    end
   end
 
   factory :vote do

--- a/spec/features/account_creation_spec.rb
+++ b/spec/features/account_creation_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe 'Account creation' do
+  describe 'visiting config page as a maintainer' do
+    before :each do
+      @maintainer = create :confirmed_account
+      log_in @maintainer
+      visit root_path
+
+      within '#main-navigation' do
+        click_link 'Configuration'
+      end
+    end
+
+    it 'has a link to create account' do
+      within '#new_presenter_link' do
+        page.should have_content 'New presenter/Maintainer'
+      end
+    end
+
+    describe 'clicking new account link' do
+      before :each do
+        click_link 'New presenter/Maintainer'
+      end
+
+      it 'displays a form to add accounts' do
+        page.should have_css 'form#new_presenter'
+
+        within 'form#new_presenter' do
+          page.should have_css 'input#presenter_email'
+          page.should have_css 'select#presenter_role'
+          page.should have_css 'input[type="submit"]'
+        end
+      end
+
+      shared_examples_for :account_creation do
+        it 'hides form' do
+          page.should have_no_css 'form#new_presenter'
+        end
+
+        it 'notices confirmation email has been sent' do
+          within '#account-creation' do
+            page.should have_content 'Confirmation email has been sent'
+          end
+        end
+      end
+
+      describe 'filling account form to create maintainer' do
+        before :each do
+          within '#new_presenter' do
+            fill_in 'Email', with: 'test-maintainer@example.com'
+            select 'maintainer', from: 'presenter_role'
+
+            click_button 'Create Presenter'
+          end
+        end
+
+        it_behaves_like :account_creation
+      end
+
+      describe 'filling account form to create maintainer' do
+        before :each do
+          within '#new_presenter' do
+            fill_in 'Email', with: 'test-maintainer@example.com'
+            select 'presenter', from: 'presenter_role'
+
+            click_button 'Create Presenter'
+          end
+        end
+
+        it_behaves_like :account_creation
+      end
+    end
+  end
+
+  describe 'Following confirmation link' do
+    before :each do
+      @presenter = create :presenter_account
+      visit confirm_account_path( id: @presenter.confirmation_token )
+    end
+
+    it 'displays password edition form' do
+      within 'h1' do
+        page.should have_content 'Change password'
+      end
+
+      page.should have_css 'form#edit_account'
+    end
+
+    describe 'updating password' do
+      before :each do
+        within 'form#edit_account' do
+          fill_in 'account_password', with: 'new_password'
+          fill_in 'account_password_confirmation', with: 'new_password'
+          click_button 'Update Account'
+        end
+      end
+
+      it 'shows logged in user home' do
+        within '#main-navigation' do
+          page.should have_content 'Dashboard'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/menu_spec.rb
+++ b/spec/lib/menu_spec.rb
@@ -19,7 +19,7 @@ describe Menu do
   end
 
   before do
-    ActionGuard.stub!(:authorized?).and_return true
+    ActionGuard.stub(:authorized?).and_return true
   end
 
   describe "render a menu tab" do
@@ -33,7 +33,7 @@ describe Menu do
     end
 
     it "renders nothing when not authorized" do
-      ActionGuard.stub!(:authorized?).and_return false
+      ActionGuard.stub(:authorized?).and_return false
       menu.tab("LinkName", 'controller_path').render(request_params_for('home'), "some_account").should == ''
     end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -41,6 +41,19 @@ describe Account do
     end
   end
 
+  describe 'create' do
+    before :each do
+      @account = Account.new
+      @account.email = 'test@example.com'
+      @account.role = 'maintainer'
+      @account.save!
+    end
+
+    it 'sets confirmation_token' do
+      @account.confirmation_token.should_not be_nil
+    end
+  end
+
   describe 'authenticate' do
     let!(:account) { FactoryGirl.create :maintainer_account } 
 

--- a/spec/models/presenter_spec.rb
+++ b/spec/models/presenter_spec.rb
@@ -5,7 +5,7 @@ describe Presenter do
   def create_presenter
     presenter
   end
-  let (:maintainer) { FactoryGirl.create :presenter, :account =>  (FactoryGirl.create :confirmed_account)}
+  let (:maintainer) { create( :confirmed_account).presenter }
   def create_maintainer
     maintainer
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,8 @@ RSpec.configure do |config|
   config.filter_run 
   config.run_all_when_everything_filtered = true
 
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+
   config.before(:suite) do
     DatabaseCleaner.strategy = :deletion
     DatabaseCleaner.clean_with( :truncation )


### PR DESCRIPTION
Account creation from configuration page is now complete. It seems this
feature actually was never finished, since :
1. it contains a "name" input that does not reflect in database
2. it creates accounts, but they can't be confirmed

Added confirmation action so that created users receive a confirmation
email with a link to confirm their account. Once confirmed, they are
immediately displayed password edition form.

When a maintainer create an account, he's now warned a confirmation mail
has been sent.

Close #13

Details :
- ADD Account#confirmation_token
- ADD generate confirmation_token for new accounts
- ADD accounts#confirm
- ADD confirmation mailer
- REFACTOR send confirmation email on presenters#create
- REFACTOR warns confirmation has been sent when creating account
- UPDATE readme
