### PR TITLE
FIX rake's vlad interference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,6 @@ group :test do
   gem 'database_cleaner'
 end
 
-group :rake do
-  gem 'vlad'
-  gem 'vlad-git'
-end
-
 group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ GEM
       mini_portile (~> 0.5.0)
     nokogiri (1.6.0-x86-mingw32)
       mini_portile (~> 0.5.0)
-    open4 (1.3.0)
     pdf-reader (1.3.3)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.0)
@@ -162,9 +161,6 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     rake (10.1.0)
-    rake-remote_task (2.2.1)
-      open4 (~> 1.0)
-      rake (>= 0.8, < 11.0)
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
@@ -215,11 +211,6 @@ GEM
     uglifier (2.3.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    vlad (2.6.2)
-      rake (>= 0.8, < 11.0)
-      rake-remote_task (~> 2.1)
-    vlad-git (2.2.0)
-      vlad (>= 2.1.0)
     websocket-driver (0.3.0)
     win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
@@ -253,5 +244,3 @@ DEPENDENCIES
   shoulda-matchers
   therubyracer
   uglifier (>= 1.0.3)
-  vlad
-  vlad-git


### PR DESCRIPTION
Having vlad in rake task causes [top level methods name conflicts](https://github.com/seattlerb/vlad/issues/21).

Symptom for this is this error :

```
$ RAILS_ENV=test rake db:migrate
rake aborted!
host required
```

Since we use heroku, we don't need vlad anyway, which is a tool for
deployment on dedicated servers.

Removed it from dependencies.

Close #6 (travis problem was that one)
