### PR TITLE
Calmer le captcha

### DIFF
--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,5 +1,5 @@
 Recaptcha.configure do |config|
-  config.public_key  = '6Ld_GcQSAAAAAAhIvwcgalcQAPEJLrDDrNS17pAt'
-  config.private_key = '6Ld_GcQSAAAAAIeIaUTrf33OwqK5-Ltpl5JWWRcL'
+  config.public_key  = '6LcMogQTAAAAAO6clPZ9cZAI4qAMYXNXrcMrg0-0'
+  config.private_key = '6LcMogQTAAAAAExIg4dXRDvhIdIRgAXqbwOJBuqs'
 end
 


### PR DESCRIPTION
@dboissier le recaptcha se plaint que la clef ne correspond pas au domaine, du coup j'ai régénéré une paire de clefs que j'ai attachées au domaine de notre CFP. Si ça te parait logique, tu peux merger et déployer STP ?