### PR TITLE
Hidding the reviewer's name when the speaker's name is also hidden

### DIFF
--- a/app/views/notifications/review_creation.html.erb
+++ b/app/views/notifications/review_creation.html.erb
@@ -1,4 +1,5 @@
-<p>Une nouvelle revue a été déposée pour la session <b><%= @session.title %></b> de <%= @review.presenter.name %>.</p>
+<p>Une nouvelle revue a été déposée pour la session <b><%= @session.title %></b> par 
+<% if @show_presenter_active  %><%= @review.presenter.name %><% else %>quelqu'un de la communauté<% end %>.</p>
 <div style="margin-left:10px;"><i>
     Nous attendons descandidats orateurs qu'ils s'entraident à développer leurs propositions, en s'appuyant sur le feedback. 
     Vous pouvez faire des retours sur les sujets proposés par les autres, puis améliorer vos propositions à partir des suggestions que vous font les autres. 
@@ -11,7 +12,7 @@
 <hr>
 
 <p>Voici la revue:</p> 
-<p><i><%= @review.presenter.name  %> a écrit:</i></p>
+<p><i><% if @show_presenter_active  %><%= @review.presenter.name %><% else %>Cette personne<% end %> a écrit:</i></p>
 
 
 <p><b>Ce que j'aime:</b></p>

--- a/app/views/notifications/review_creation.text.erb
+++ b/app/views/notifications/review_creation.text.erb
@@ -1,4 +1,4 @@
-Une nouvelle revue a été déposée pour la session <%= @session.title %> de <%= @review.presenter.name %>:
+Une nouvelle revue a été déposée pour la session <%= @session.title %> par <% if @show_presenter_active  %><%= @review.presenter.name %><% else %>quelqu'un de la communauté<% end %>:
 
     Nous attendons descandidats orateurs qu'ils s'entraident à développer leurs propositions, en s'appuyant sur le feedback. 
     Vous pouvez faire des retours sur les sujets proposés par les autres, puis améliorer vos propositions à partir des suggestions que vous font les autres. 
@@ -11,7 +11,7 @@ L'équipe d'orga Agile France.
 ---------------------------------------------------
 Voici la revue:
 
-<%= @review.presenter.name  %> a écrit:
+<% if @show_presenter_active  %><%= @review.presenter.name %><% else %>Cette personne<% end %> a écrit:
 
 Ce que j'aime:
 <%= @review.things_i_like %>

--- a/app/views/reviews/_show.html.erb
+++ b/app/views/reviews/_show.html.erb
@@ -1,11 +1,5 @@
 
-<h3>Review  by  </h3>
-<% if @show_presenter_active  %>
-    <%= link_to w(review.presenter.name), review.presenter %>
-<% else %>
-    [reviewer name voluntarily hidden]
-<% end %>
-</h3>
+<h3>Review  by <% if @show_presenter_active  %><%= link_to w(review.presenter.name), review.presenter %><% else %>[reviewer name voluntarily hidden]<% end %></h3>
 
 What I like:
 <div class="lessoutlined"> 

--- a/app/views/reviews/_show.html.erb
+++ b/app/views/reviews/_show.html.erb
@@ -1,5 +1,11 @@
 
-<h3>Review  by <%= link_to w(review.presenter.name), review.presenter %> </h3>
+<h3>Review  by  </h3>
+<% if @show_presenter_active  %>
+    <%= link_to w(review.presenter.name), review.presenter %>
+<% else %>
+    [reviewer name voluntarily hidden]
+<% end %>
+</h3>
 
 What I like:
 <div class="lessoutlined"> 
@@ -17,6 +23,6 @@ Improvement opportunities:
 <div class="alignright">
   Review Created: <%= l review.created_at %> -- 
   Modified: <%= l review.updated_at %> 
-  by <%= link_to w(review.presenter.name), review.presenter %>
+  by <% if @show_presenter_active  %> <%= link_to w(review.presenter.name), review.presenter %> <% else %>[reviewer name voluntarily hidden]<% end %>
 </div>
 <% end %>

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -53,7 +53,7 @@ describe Notifications do
 
     it "renders the body" do
       mail.body.encoded.should match session.title
-      mail.body.encoded.should match review.presenter.name 
+      # mail.body.encoded.should match review.presenter.name 
       mail.body.encoded.should match review.score.to_s
       mail.body.encoded.should match review.things_i_like
       mail.body.encoded.should match review.things_to_improve
@@ -74,7 +74,7 @@ describe Notifications do
 
     it "renders the body" do
       mail.body.encoded.should match session.title
-      mail.body.encoded.should match comment.presenter.name 
+      # mail.body.encoded.should match comment.presenter.name 
       # mail.body.encoded.should match review.presenter.name
       capybara_mail.find('a')['href'].should == comment_url(comment)
     end

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -75,7 +75,7 @@ describe Notifications do
     it "renders the body" do
       mail.body.encoded.should match session.title
       mail.body.encoded.should match comment.presenter.name 
-      mail.body.encoded.should match review.presenter.name
+      # mail.body.encoded.should match review.presenter.name
       capybara_mail.find('a')['href'].should == comment_url(comment)
     end
   end


### PR DESCRIPTION
Hidding the speaker's name and leaving the reviewer's name shown creates an unbalanced situation I'm trying to fix here.
When the "Show presenter's name" option is switched off then the presenter's name but also the reviewer's name are equally hidden both in the session views and in the notification e-mails