### PR TITLE
	Hidding reviewer's name in the notification e-mail

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -92,8 +92,11 @@ class SessionsController < ApplicationController
     @sessions = Session.all
     session_csv = CSV.generate(options = { :col_sep => ';' }) do |csv| 
       #header row
-      csv << [ "Titre", "Soustitre",
-        "Orateurs", "Créée", "Modifiée",
+      csv << [ "Titre", "Soustitre"]
+      <% if @show_presenter_active %>
+        csv << [ ""Orateurs""]
+      <% end %>
+      csv << ["Créée", "Modifiée",
         "Langue", "Nature", "Durée",
         "Revue",
         "Objectif",
@@ -102,8 +105,11 @@ class SessionsController < ApplicationController
         "Desc. Courte" ]
       #data row
       @sessions.each do |session| 
-        csv << [ session.title, session.sub_title, 
-          session.presenter_names, session.created_at, session.updated_at,
+        csv << [ session.title, session.sub_title ].collect {|field| (field.blank?) ?  "(none)" : field }
+        <% if @show_presenter_active %>
+          csv << [ session.presenter_names ]
+        <% end %>        
+        csv <<  [ session.created_at, session.updated_at,
           session.session_type, session.topic_name, session.duration,
           session.reviews.size,
           session.session_goal,

--- a/app/views/notifications/comment_creation.html.erb
+++ b/app/views/notifications/comment_creation.html.erb
@@ -1,4 +1,4 @@
-<p>Un nouveau commentaire a été déposé sur <% if @show_presenter_active  %>la revue de <%= @review.presenter.name %><% else %>la revue quelqu'un de la communauté<% end %> pour la session <b><%= @session.title %></b>
+<p>Un nouveau commentaire a été déposé sur <% if @show_presenter_active  %>la revue de <%= @review.presenter.name %><% else %>la revue de quelqu'un de la communauté<% end %> pour la session <b><%= @session.title %></b>
     <% if should_hide_presenter @comment %>
         proposée par un orateur
     <% else %>

--- a/app/views/notifications/comment_creation.html.erb
+++ b/app/views/notifications/comment_creation.html.erb
@@ -1,4 +1,4 @@
-<p>Un nouveau commentaire a été déposé sur la revue de <%= @review.presenter.name %> pour la session <b><%= @session.title %></b>
+<p>Un nouveau commentaire a été déposé sur <% if @show_presenter_active  %>la revue de <%= @review.presenter.name %><% else %>la revue quelqu'un de la communauté<% end %> pour la session <b><%= @session.title %></b>
     <% if should_hide_presenter @comment %>
         proposée par un orateur
     <% else %>

--- a/app/views/notifications/comment_creation.text.erb
+++ b/app/views/notifications/comment_creation.text.erb
@@ -1,4 +1,4 @@
-Un nouveau commentaire a été déposé sur la revue de <%= @review.presenter.name %> pour la session <%= @session.title %> proposée par
+Un nouveau commentaire a été déposé sur <% if @show_presenter_active %>la revue de <%= @review.presenter.name %><% else %>la revue de quelqu'un de la communauté<% end %> pour la session <%= @session.title %> proposée par
 <% if should_hide_presenter @comment %>
     proposée par un orateur
 <% else %>


### PR DESCRIPTION
La fonctionnalité n'avait pas été mise pour la notification de commentaire par l'orateur sur une review (cf. mon mail)