### PR TITLE
Quick fix to avoid displaying reviewers name if this one comments

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -96,7 +96,7 @@ module ApplicationHelper
   end
 
   def should_hide_presenter(comment)
-    !@show_presenter_active and comment.review.session.presenter_names.include? comment.presenter.name
+    !@show_presenter_active
   end
 
   def collapse_button_initially_open(div_id)


### PR DESCRIPTION
Currently the name of the reviewer appears if this one comments his own review (for instance after the presenter made a comment)